### PR TITLE
Fix typo in tor proxy replica example

### DIFF
--- a/example/templates/torproxy_replica/torproxy.yaml
+++ b/example/templates/torproxy_replica/torproxy.yaml
@@ -14,4 +14,4 @@ spec:
       - name: socks
         port: 9050
         protocol: SOCKS
-  replica: 3
+  deployment.replicas: 3


### PR DESCRIPTION
The tor proxy replica example does not work for me. I think it should read `deployment.replicas` instead of `replica`.