### PR TITLE
fix: replace panics with proper error propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Replace panics with error propagation.
+
 ## [1.0.8] - 2026-04-12
 
 - Third party Tor v0.4.9.6 container image with OpenSSL 3.6.2. (linux/amd64, linux/arm64)
@@ -365,17 +369,11 @@
 <!-- next-url -->
 
 [Unreleased]: https://github.com/agabani/tor-operator/compare/v1.0.8...HEAD
-
 [1.0.8]: https://github.com/agabani/tor-operator/compare/v1.0.7...v1.0.8
-
 [1.0.7]: https://github.com/agabani/tor-operator/compare/v1.0.6...v1.0.7
-
 [1.0.6]: https://github.com/agabani/tor-operator/compare/v1.0.5...v1.0.6
-
 [1.0.5]: https://github.com/agabani/tor-operator/compare/v1.0.4...v1.0.5
-
 [1.0.4]: https://github.com/agabani/tor-operator/compare/v1.0.3...v1.0.4
-
 [1.0.3]: https://github.com/agabani/tor-operator/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/agabani/tor-operator/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/agabani/tor-operator/compare/v1.0.0...v1.0.1

--- a/src/kubernetes/api.rs
+++ b/src/kubernetes/api.rs
@@ -211,11 +211,9 @@ where
             }
         }
 
-        assert!(
-            resources.is_empty(),
-            "{} resources were not patched",
-            resources.len()
-        );
+        if !resources.is_empty() {
+            return Err(Error::SyncInvariantViolated(resources.len()));
+        }
 
         Ok((patched, deprecated))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ pub mod tor_proxy;
 #[derive(Debug)]
 pub enum Error {
     Kube(kube::Error),
+    MissingConfiguration(&'static str),
     MissingObjectKey(&'static str),
+    SyncInvariantViolated(usize),
 }
 
 impl std::error::Error for Error {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,13 @@ use tor_operator::{
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let cli = &parse();
 
-    let provider = otel::Provider::new(cli);
+    let provider = otel::Provider::new(cli)?;
     provider.init_tracing_subscriber();
 
     match &cli.command {
         CliCommands::Controller(controller) => match &controller.command {
             ControllerCommands::Run(run) => {
-                controller_run(cli, controller, run, provider.meter()).await;
+                controller_run(cli, controller, run, provider.meter()).await?;
             }
         },
         CliCommands::Crd(crd) => match &crd.command {
@@ -49,10 +49,10 @@ async fn controller_run(
     _controller: &ControllerArgs,
     run: &ControllerRunArgs,
     meter_provider: &opentelemetry_sdk::metrics::SdkMeterProvider,
-) {
-    let addr = format!("{}:{}", run.host, run.port).parse().unwrap();
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let addr = format!("{}:{}", run.host, run.port).parse()?;
 
-    let client = kube::Client::try_default().await.unwrap();
+    let client = kube::Client::try_default().await?;
 
     let onion_balance_config = onion_balance::Config {
         onion_balance_image: onion_balance::ImageConfig {
@@ -93,6 +93,8 @@ async fn controller_run(
         () = tor_ingress::run_controller(client.clone(), tor_ingress_config, metrics.clone()) => {},
         () = tor_proxy::run_controller(client.clone(), tor_proxy_config, metrics.clone()) => {},
     }
+
+    Ok(())
 }
 
 fn crd_generate(_cli: &CliArgs, _crd: &CrdArgs, generate: &CrdGenerateArgs) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,7 +62,9 @@ impl Metrics {
     pub fn reconcile_failure(&self, controller: &'static str, error: &Error) {
         let error = match error {
             Error::Kube(_) => "kube",
+            Error::MissingConfiguration(_) => "missing configuration",
             Error::MissingObjectKey(_) => "missing object key",
+            Error::SyncInvariantViolated(_) => "sync invariant violated",
         };
         self.reconciliation_errors_total.add(
             1,

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -14,7 +14,10 @@ use tracing_subscriber::{
     EnvFilter, Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _,
 };
 
-use crate::cli::{CliArgs, CliArgsOtelExporter};
+use crate::{
+    Error, Result,
+    cli::{CliArgs, CliArgsOtelExporter},
+};
 
 pub struct Provider {
     logger: opentelemetry_sdk::logs::SdkLoggerProvider,
@@ -24,14 +27,16 @@ pub struct Provider {
 }
 
 impl Provider {
-    #[must_use]
-    pub fn new(cli: &CliArgs) -> Self {
-        Self {
-            logger: logger_provider(cli),
-            meter: meter_provider(cli),
+    /// # Errors
+    ///
+    /// Will return `Err` if OTEL endpoint or protocol configuration is missing.
+    pub fn new(cli: &CliArgs) -> Result<Self> {
+        Ok(Self {
+            logger: logger_provider(cli)?,
+            meter: meter_provider(cli)?,
             service_name: service_name(cli),
-            tracer: tracer_provider(cli),
-        }
+            tracer: tracer_provider(cli)?,
+        })
     }
 
     #[must_use]
@@ -144,55 +149,55 @@ fn traces_compression(cli: &CliArgs) -> Option<Compression> {
  * ============================================================================
  */
 
-fn logs_endpoint(cli: &CliArgs, protocol: Protocol) -> String {
+fn logs_endpoint(cli: &CliArgs, protocol: Protocol) -> Result<String> {
     if let Some(endpoint) = &cli.otel_exporter_otlp_logs_endpoint {
-        return endpoint.clone();
+        return Ok(endpoint.clone());
     }
 
     if let Some(endpoint) = &cli.otel_exporter_otlp_endpoint {
-        return match protocol {
+        return Ok(match protocol {
             Protocol::Grpc => endpoint.clone(),
-            Protocol::HttpBinary | Protocol::HttpJson => {
-                format!("{endpoint}/v1/logs")
-            }
-        };
+            Protocol::HttpBinary | Protocol::HttpJson => format!("{endpoint}/v1/logs"),
+        });
     }
 
-    panic!("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT must be set");
+    Err(Error::MissingConfiguration(
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT must be set",
+    ))
 }
 
-fn metrics_endpoint(cli: &CliArgs, protocol: Protocol) -> String {
+fn metrics_endpoint(cli: &CliArgs, protocol: Protocol) -> Result<String> {
     if let Some(endpoint) = &cli.otel_exporter_otlp_metrics_endpoint {
-        return endpoint.clone();
+        return Ok(endpoint.clone());
     }
 
     if let Some(endpoint) = &cli.otel_exporter_otlp_endpoint {
-        return match protocol {
+        return Ok(match protocol {
             Protocol::Grpc => endpoint.clone(),
-            Protocol::HttpBinary | Protocol::HttpJson => {
-                format!("{endpoint}/v1/metrics")
-            }
-        };
+            Protocol::HttpBinary | Protocol::HttpJson => format!("{endpoint}/v1/metrics"),
+        });
     }
 
-    panic!("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT must be set");
+    Err(Error::MissingConfiguration(
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT must be set",
+    ))
 }
 
-fn traces_endpoint(cli: &CliArgs, protocol: Protocol) -> String {
+fn traces_endpoint(cli: &CliArgs, protocol: Protocol) -> Result<String> {
     if let Some(endpoint) = &cli.otel_exporter_otlp_traces_endpoint {
-        return endpoint.clone();
+        return Ok(endpoint.clone());
     }
 
     if let Some(endpoint) = &cli.otel_exporter_otlp_endpoint {
-        return match protocol {
+        return Ok(match protocol {
             Protocol::Grpc => endpoint.clone(),
-            Protocol::HttpBinary | Protocol::HttpJson => {
-                format!("{endpoint}/v1/traces")
-            }
-        };
+            Protocol::HttpBinary | Protocol::HttpJson => format!("{endpoint}/v1/traces"),
+        });
     }
 
-    panic!("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT must be set");
+    Err(Error::MissingConfiguration(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT must be set",
+    ))
 }
 
 /*
@@ -228,25 +233,31 @@ fn traces_headers(cli: &CliArgs) -> Option<&str> {
  * ============================================================================
  */
 
-fn logs_protocol(cli: &CliArgs) -> Protocol {
+fn logs_protocol(cli: &CliArgs) -> Result<Protocol> {
     cli.otel_exporter_otlp_logs_protocol
         .or(cli.otel_exporter_otlp_protocol)
-        .expect("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL or OTEL_EXPORTER_OTLP_PROTOCOL must be set")
-        .into()
+        .ok_or(Error::MissingConfiguration(
+            "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL or OTEL_EXPORTER_OTLP_PROTOCOL must be set",
+        ))
+        .map(Into::into)
 }
 
-fn metrics_protocol(cli: &CliArgs) -> Protocol {
+fn metrics_protocol(cli: &CliArgs) -> Result<Protocol> {
     cli.otel_exporter_otlp_metrics_protocol
         .or(cli.otel_exporter_otlp_protocol)
-        .expect("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL or OTEL_EXPORTER_OTLP_PROTOCOL must be set")
-        .into()
+        .ok_or(Error::MissingConfiguration(
+            "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL or OTEL_EXPORTER_OTLP_PROTOCOL must be set",
+        ))
+        .map(Into::into)
 }
 
-fn traces_protocol(cli: &CliArgs) -> Protocol {
+fn traces_protocol(cli: &CliArgs) -> Result<Protocol> {
     cli.otel_exporter_otlp_traces_protocol
         .or(cli.otel_exporter_otlp_protocol)
-        .expect("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL or OTEL_EXPORTER_OTLP_PROTOCOL must be set")
-        .into()
+        .ok_or(Error::MissingConfiguration(
+            "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL or OTEL_EXPORTER_OTLP_PROTOCOL must be set",
+        ))
+        .map(Into::into)
 }
 
 /*
@@ -276,7 +287,7 @@ fn traces_timeout(cli: &CliArgs) -> u64 {
  * ============================================================================
  */
 
-fn logger_provider(cli: &CliArgs) -> SdkLoggerProvider {
+fn logger_provider(cli: &CliArgs) -> Result<SdkLoggerProvider> {
     let mut provider_builder = SdkLoggerProvider::builder().with_resource(resource(cli));
 
     if let Some(exporter) = &cli.otel_logs_exporter {
@@ -287,8 +298,8 @@ fn logger_provider(cli: &CliArgs) -> SdkLoggerProvider {
 
         if exporter.contains(&CliArgsOtelExporter::Otlp) {
             let compression = logs_compression(cli);
-            let protocol = logs_protocol(cli);
-            let endpoint = logs_endpoint(cli, protocol);
+            let protocol = logs_protocol(cli)?;
+            let endpoint = logs_endpoint(cli, protocol)?;
             let headers = log_headers(cli);
             let timeout = logs_timeout(cli);
 
@@ -323,10 +334,10 @@ fn logger_provider(cli: &CliArgs) -> SdkLoggerProvider {
         }
     }
 
-    provider_builder.build()
+    Ok(provider_builder.build())
 }
 
-fn meter_provider(cli: &CliArgs) -> SdkMeterProvider {
+fn meter_provider(cli: &CliArgs) -> Result<SdkMeterProvider> {
     let mut provider_builder = SdkMeterProvider::builder().with_resource(resource(cli));
 
     if let Some(exporter) = &cli.otel_metrics_exporter {
@@ -337,8 +348,8 @@ fn meter_provider(cli: &CliArgs) -> SdkMeterProvider {
 
         if exporter.contains(&CliArgsOtelExporter::Otlp) {
             let compression = metrics_compression(cli);
-            let protocol = metrics_protocol(cli);
-            let endpoint = metrics_endpoint(cli, protocol);
+            let protocol = metrics_protocol(cli)?;
+            let endpoint = metrics_endpoint(cli, protocol)?;
             let headers = metrics_headers(cli);
             let timeout = metrics_timeout(cli);
 
@@ -373,10 +384,10 @@ fn meter_provider(cli: &CliArgs) -> SdkMeterProvider {
         }
     }
 
-    provider_builder.build()
+    Ok(provider_builder.build())
 }
 
-fn tracer_provider(cli: &CliArgs) -> SdkTracerProvider {
+fn tracer_provider(cli: &CliArgs) -> Result<SdkTracerProvider> {
     let mut provider_builder = SdkTracerProvider::builder().with_resource(resource(cli));
 
     if let Some(exporter) = &cli.otel_traces_exporter {
@@ -387,8 +398,8 @@ fn tracer_provider(cli: &CliArgs) -> SdkTracerProvider {
 
         if exporter.contains(&CliArgsOtelExporter::Otlp) {
             let compression = traces_compression(cli);
-            let protocol = traces_protocol(cli);
-            let endpoint = traces_endpoint(cli, protocol);
+            let protocol = traces_protocol(cli)?;
+            let endpoint = traces_endpoint(cli, protocol)?;
             let headers = traces_headers(cli);
             let timeout = traces_timeout(cli);
 
@@ -423,7 +434,7 @@ fn tracer_provider(cli: &CliArgs) -> SdkTracerProvider {
         }
     }
 
-    provider_builder.build()
+    Ok(provider_builder.build())
 }
 
 /*


### PR DESCRIPTION
- Replace assert!() in api::update() with Err(Error::SyncInvariantViolated) so transient list failures after patch trigger a requeue instead of crashing
- Replace panic!()/expect() in otel endpoint and protocol helpers with Result returns; Provider::new() now propagates MissingConfiguration errors
- Make controller_run() return Result and use ? for addr parse and kube client init instead of unwrap()
- Add MissingConfiguration and SyncInvariantViolated variants to Error enum