### PR TITLE
chore(ci): set mark_as_latest=false on chart-releaser to avoid unbound variable crash

### DIFF
--- a/.github/workflows/cd-post-release.yaml
+++ b/.github/workflows/cd-post-release.yaml
@@ -244,6 +244,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           config: chart-releaser.yaml
+          mark_as_latest: false
           skip_packaging: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
helm/chart-releaser-action@v1.7.0 introduced a bug in cr.sh where `latest_tag` is accessed but never set when `--mark-as-latest true` is passed and no new GitHub release is created. This aligns the action input with the existing chart-releaser.yaml intent (make-release-latest: false) and bypasses the buggy code path.