### PR TITLE
feat: support env *_IMAGE_REPOSITORY and *_IMAGE_TAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+-  CLI option ONION_BALANCE_IMAGE_REPOSITORY.
+-  CLI option ONION_BALANCE_IMAGE_TAG.
+-  CLI option TOR_IMAGE_REPOSITORY.
+-  CLI option TOR_IMAGE_TAG.
+
 ## [1.0.13] - 2026-07-01
 
 ### Added

--- a/charts/tor-operator/templates/deployment.yaml
+++ b/charts/tor-operator/templates/deployment.yaml
@@ -42,12 +42,19 @@ spec:
             - "controller"
             - "run"
 
-            {{- if .Values.onionBalance }} # depreciated: use .Values.env.ONION_BALANCE_*
+            {{- if (((.Values.onionBalance).image).pullPolicy) }} # depreciated: use .Values.env.ONION_BALANCE_IMAGE_PULL_POLICY
             - "--onion-balance-image-pull-policy"
             - "{{ .Values.onionBalance.image.pullPolicy }}"
+            {{- end }}
 
-            - "--onion-balance-image-uri"
-            - "{{ .Values.onionBalance.image.repository }}:{{ .Values.onionBalance.image.tag }}"
+            {{- if (((.Values.onionBalance).image).repository) }} # depreciated: use .Values.env.ONION_BALANCE_IMAGE_REPOSITORY
+            - "--onion-balance-image-repository"
+            - "{{ .Values.onionBalance.image.repository }}"
+            {{- end }}
+
+            {{- if (((.Values.onionBalance).image).tag) }} # depreciated: use .Values.env.ONION_BALANCE_IMAGE_TAG
+            - "--onion-balance-image-tag"
+            - "{{ .Values.onionBalance.image.tag }}"
             {{- end }}
 
             - "--host"
@@ -56,12 +63,19 @@ spec:
             - "--port"
             - "{{ .Values.service.port }}"
 
-            {{- if .Values.tor }} # depreciated: use .Values.env.TOR_*
+            {{- if (((.Values.tor).image).pullPolicy) }} # depreciated: use .Values.env.TOR_IMAGE_PULL_POLICY
             - "--tor-image-pull-policy"
             - "{{ .Values.tor.image.pullPolicy }}"
+            {{- end }}
 
-            - "--tor-image-uri"
-            - "{{ .Values.tor.image.repository }}:{{ .Values.tor.image.tag }}"
+            {{- if (((.Values.tor).image).repository) }} # depreciated: use .Values.env.TOR_IMAGE_REPOSITORY
+            - "--tor-image-repository"
+            - "{{ .Values.tor.image.repository }}"
+            {{- end }}
+
+            {{- if (((.Values.tor).image).tag) }} # depreciated: use .Values.env.TOR_IMAGE_TAG
+            - "--tor-image-tag"
+            - "{{ .Values.tor.image.tag }}"
             {{- end }}
           ports:
             - name: http

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,13 +206,21 @@ pub struct ControllerRunArgs {
     #[arg(long, env, default_value = "IfNotPresent")]
     pub onion_balance_image_pull_policy: String,
 
+    /// Onion Balance image repository
+    #[arg(long, env)]
+    onion_balance_image_repository: Option<String>,
+
+    /// Onion Balance image tag
+    #[arg(long, env)]
+    onion_balance_image_tag: Option<String>,
+
     /// Onion Balance image uri
     #[arg(
         long,
         env,
         default_value = "ghcr.io/agabani/tor-operator:onion-balance-0.2.4.0"
     )]
-    pub onion_balance_image_uri: String,
+    onion_balance_image_uri: String,
 
     /// Host the web server binds to
     #[arg(long, env, default_value = "127.0.0.1")]
@@ -226,13 +234,60 @@ pub struct ControllerRunArgs {
     #[arg(long, env, default_value = "IfNotPresent")]
     pub tor_image_pull_policy: String,
 
+    /// Tor image repository
+    #[arg(long, env)]
+    tor_image_repository: Option<String>,
+
+    /// Tor image tag
+    #[arg(long, env)]
+    tor_image_tag: Option<String>,
+
     /// Tor image uri
     #[arg(
         long,
         env,
         default_value = "ghcr.io/agabani/tor-operator:tor-0.4.9.11.0"
     )]
-    pub tor_image_uri: String,
+    tor_image_uri: String,
+}
+
+impl ControllerRunArgs {
+    #[must_use]
+    pub fn onion_balance_image_uri(&self) -> String {
+        let mut parts = self.onion_balance_image_uri.split(':');
+
+        let Some(repository) = parts.next() else {
+            return self.onion_balance_image_uri.clone();
+        };
+        let Some(tag) = parts.next() else {
+            return self.onion_balance_image_uri.clone();
+        };
+
+        let repository = self
+            .onion_balance_image_repository
+            .as_deref()
+            .unwrap_or(repository);
+        let tag = self.onion_balance_image_tag.as_deref().unwrap_or(tag);
+
+        format!("{repository}:{tag}")
+    }
+
+    #[must_use]
+    pub fn tor_image_uri(&self) -> String {
+        let mut parts = self.tor_image_uri.split(':');
+
+        let Some(repository) = parts.next() else {
+            return self.tor_image_uri.clone();
+        };
+        let Some(tag) = parts.next() else {
+            return self.tor_image_uri.clone();
+        };
+
+        let repository = self.tor_image_repository.as_deref().unwrap_or(repository);
+        let tag = self.tor_image_tag.as_deref().unwrap_or(tag);
+
+        format!("{repository}:{tag}")
+    }
 }
 
 /*

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,11 +57,11 @@ async fn controller_run(
     let onion_balance_config = onion_balance::Config {
         onion_balance_image: onion_balance::ImageConfig {
             pull_policy: run.onion_balance_image_pull_policy.clone(),
-            uri: run.onion_balance_image_uri.clone(),
+            uri: run.onion_balance_image_uri(),
         },
         tor_image: onion_balance::ImageConfig {
             pull_policy: run.tor_image_pull_policy.clone(),
-            uri: run.tor_image_uri.clone(),
+            uri: run.tor_image_uri(),
         },
     };
 
@@ -70,7 +70,7 @@ async fn controller_run(
     let onion_service_config = onion_service::Config {
         tor_image: onion_service::ImageConfig {
             pull_policy: run.tor_image_pull_policy.clone(),
-            uri: run.tor_image_uri.clone(),
+            uri: run.tor_image_uri(),
         },
     };
 
@@ -79,7 +79,7 @@ async fn controller_run(
     let tor_proxy_config = tor_proxy::Config {
         tor_image: tor_proxy::ImageConfig {
             pull_policy: run.tor_image_pull_policy.clone(),
-            uri: run.tor_image_uri.clone(),
+            uri: run.tor_image_uri(),
         },
     };
 


### PR DESCRIPTION
Support for overriding `<repository>` and `<tag>` parts of the default Onion Balance and Tor Docker URI `<repository>:<tag>`

Example:

```yaml
# values.yaml
env:
  ONION_BALANCE_IMAGE_REPOSITORY:
    value: <private-registry>/agabani/tor-operator
  TOR_IMAGE_REPOSITORY:
    value: <private-registry>/agabani/tor-operator
```

Resolves #518